### PR TITLE
fix: make image rewrite top priority

### DIFF
--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -44,7 +44,8 @@ export const onBuild: OnBuild = async ({ constants, netlifyConfig, utils }) => {
     ],
     included_files: [path.join(functionDir, 'jobs', '**', '*.json')],
   }
-  netlifyConfig.redirects.push({
+  // Needs to go first to avoid being overridden by catchall
+  netlifyConfig.redirects.unshift({
     from: '/static/:sourceDigest/:queryDigest/:filename',
     to: '/.netlify/builders/gatsby-image',
     status: 200,


### PR DESCRIPTION
Ensures that the rewrite mapping image requests to the image function goes at the start of the rewrites list. Having it at the end means it's overridden by catchall rewrites from the Gatsby build plugin